### PR TITLE
Add TEST/testImm instructions to AMD64AsmBuilder

### DIFF
--- a/src/main/java/com/yasuenag/ffmasm/amd64/AMD64AsmBuilder.java
+++ b/src/main/java/com/yasuenag/ffmasm/amd64/AMD64AsmBuilder.java
@@ -352,6 +352,65 @@ public class AMD64AsmBuilder<T extends AMD64AsmBuilder<T>> extends AsmBuilder<T>
   }
 
   /**
+   * TEST r/m, r.
+   *   Opcode: 84 /r (8 bit)
+   *           85 /r (16/32/64 bit)
+   *   Instruction: TEST r/m, r
+   *   Op/En: MR
+   *
+   * @param r "r" register
+   * @param m "r/m" register
+   * @param disp Displacement. Set "empty" if this operation is reg-reg.
+   * @return This instance
+   */
+  public T test(Register r, Register m, OptionalInt disp){
+    emitREXOp(r, m);
+    byte opcode = (r.width() == 8) ? (byte)0x84 : (byte)0x85;
+    byteBuf.put(opcode); // TEST
+    byte mode = emitModRM(r, m, disp);
+    emitDisp(mode, disp, m);
+    return castToT();
+  }
+
+  /**
+   * TEST r/m, imm.
+   *   Opcode: F6 /0 ib (8 bit)
+   *           F7 /0 iw/id (16/32/64 bit)
+   *   Instruction: TEST r/m, imm
+   *   Op/En: MI
+   *
+   * @param m "r/m" register
+   * @param imm Immediate value to test.
+   * @param disp Displacement. Set "empty" if this operation is reg-reg.
+   * @return This instance
+   */
+  public T testImm(Register m, int imm, OptionalInt disp){
+    Register dummy = switch(m.width()){
+      case  8 -> Register.AL;
+      case 16 -> Register.AX;
+      case 32 -> Register.EAX;
+      default -> Register.RAX;
+    };
+    emitREXOp(dummy, m);
+    byte opcode = (m.width() == 8) ? (byte)0xf6 : (byte)0xf7;
+    byteBuf.put(opcode); // TEST
+    byte mode = emitModRM(m, 0, disp);
+    emitDisp(mode, disp, m);
+
+    if(m.width() == 8){
+      byteBuf.put((byte)imm); // imm8
+    }
+    else if(m.width() == 16){
+      byteBuf.putShort((short)imm); // imm16
+    }
+    else{
+      byteBuf.putInt(imm); // imm32
+    }
+
+    return castToT();
+  }
+
+  /**
    * Returns processor identification and feature information to
    * the EAX, EBX, ECX, and EDX registers, as determined by
    * input entered in EAX (in some cases, ECX as well).

--- a/src/test/java/com/yasuenag/ffmasm/test/amd64/AsmTest.java
+++ b/src/test/java/com/yasuenag/ffmasm/test/amd64/AsmTest.java
@@ -391,6 +391,73 @@ public class AsmTest extends TestBase{
     }
   }
 
+  @Test
+  @EnabledOnOs({OS.LINUX, OS.WINDOWS})
+  public void testTESTregisters(){
+    try(var seg = new CodeSegment()){
+      var desc = FunctionDescriptor.of(
+                   ValueLayout.JAVA_INT, // return value
+                   ValueLayout.JAVA_INT, // 1st argument
+                   ValueLayout.JAVA_INT  // 2nd argument
+                 );
+      var method = new AsmBuilder.AMD64(seg, desc)
+         /* push %rbp         */ .push(Register.RBP)
+         /* mov %rsp, %rbp    */ .movMR(Register.RSP, Register.RBP, OptionalInt.empty())
+         /* xor ret, ret      */ .xorMR(argReg.returnReg(), argReg.returnReg(), OptionalInt.empty())
+         /* test arg1, arg2   */ .test(argReg.arg2(), argReg.arg1(), OptionalInt.empty())
+         /* je zero           */ .je("zero")
+         /* mov $1, retReg    */ .movImm(argReg.returnReg(), 1)
+         /* leave             */ .leave()
+         /* ret               */ .ret()
+         /* zero:             */ .label("zero")
+         /* leave             */ .leave()
+         /* ret               */ .ret()
+                                 .build();
+
+      int actual = (int)method.invoke(3, 2); // 3 & 2 == 2 != 0 -> expect 1
+      Assertions.assertEquals(1, actual);
+
+      actual = (int)method.invoke(4, 1); // 4 & 1 == 0 -> expect 0
+      Assertions.assertEquals(0, actual);
+    }
+    catch(Throwable t){
+      Assertions.fail(t);
+    }
+  }
+
+  @Test
+  @EnabledOnOs(OS.LINUX)
+  public void testTESTImmediate(){
+    try(var seg = new CodeSegment()){
+      var desc = FunctionDescriptor.of(
+                   ValueLayout.JAVA_INT, // return value
+                   ValueLayout.JAVA_INT  // 1st argument
+                 );
+      var method = new AsmBuilder.AMD64(seg, desc)
+         /* push %rbp         */ .push(Register.RBP)
+         /* mov %rsp, %rbp    */ .movMR(Register.RSP, Register.RBP, OptionalInt.empty())
+         /* xor ret, ret      */ .xorMR(argReg.returnReg(), argReg.returnReg(), OptionalInt.empty())
+         /* test arg1, 1      */ .testImm(argReg.arg1(), 1, OptionalInt.empty())
+         /* je zero           */ .je("zero")
+         /* mov $1, retReg    */ .movImm(argReg.returnReg(), 1)
+         /* leave             */ .leave()
+         /* ret               */ .ret()
+         /* zero:             */ .label("zero")
+         /* leave             */ .leave()
+         /* ret               */ .ret()
+                                 .build();
+
+      int actual = (int)method.invoke(5); // 5 & 1 == 1 -> expect 1
+      Assertions.assertEquals(1, actual);
+
+      actual = (int)method.invoke(4); // 4 & 1 == 0 -> expect 0
+      Assertions.assertEquals(0, actual);
+    }
+    catch(Throwable t){
+      Assertions.fail(t);
+    }
+  }
+
   /**
    * Tests ADDs
    */


### PR DESCRIPTION
Add TEST/testImm instructions to AMD64AsmBuilder

Summary
- Add TEST instruction support to AMD64AsmBuilder:
  - test(Register r, Register m, OptionalInt disp): encodes TEST r/m, r
  - testImm(Register m, int imm, OptionalInt disp): encodes TEST r/m, imm
- Add unit tests to validate register and immediate forms.

Files changed
- src/main/java/com/yasuenag/ffmasm/amd64/AMD64AsmBuilder.java
  - Added test(...) and testImm(...) methods implementing Intel SDM encodings.
- src/test/java/com/yasuenag/ffmasm/test/amd64/AsmTest.java
  - Added testTESTregisters and testTESTImmediate tests.

Validation
- Ran `mvn test` locally; all tests passed.

Notes
- Implementations reuse existing emitREXOp/emitModRM/emitDisp helpers.

Generated by GitHub Copilot